### PR TITLE
Fix/ipfs upload format

### DIFF
--- a/src/utils/ipfsApi.js
+++ b/src/utils/ipfsApi.js
@@ -4,14 +4,15 @@ export default async function upload(file) {
   const authorization = "Bearer 9z5jtQjkmh2nRfFzHZ6Zt7G5";
   let url = `${ipfsGatewayBaseUrl}/upload`;
   console.log("Fetching from this url: " + url);
+  let body = new FormData();
+  body.append('file', file);
   try {
     const response = await fetch(url, {
       method: "POST",
       headers: {
-        "Content-Type": "application/json",
         Authorization: authorization,
       },
-      body: { file: file },
+      body: body,
     });
     const results = await response.json();
     console.log(results);


### PR DESCRIPTION
While reviewing your code, I realized I might not have explained the my upload route the best.

It requires a `FormData` body, and no `Content-Type: application/json` header.

I've made the update in this branch for you. Uploads should now work without issues. However, being able to upload now, I see that the song list isn't updated afterwards. Adding that would be useful - so that the user doesn't have to refresh the page to see the new songs.